### PR TITLE
INJI-163

### DIFF
--- a/biosdk-services/pom.xml
+++ b/biosdk-services/pom.xml
@@ -55,7 +55,7 @@
 
 
 		<!-- Mosip kernel -->
-		<kernel.biometrics.api.version>1.2.0.1-B2</kernel.biometrics.api.version>
+		<kernel.biometrics.api.version>1.2.1-SNAPSHOT</kernel.biometrics.api.version>
 		<kernel.logger.logback.version>1.2.0.1-B1</kernel.logger.logback.version>
 		<kernel.core.version>1.2.0.1-B1</kernel.core.version>
 		<!-- Spring -->


### PR DESCRIPTION
id-repo build is failing due to biometrics-api dependency is not up to date in biosdk.