### PR TITLE
#2384: Update POM, helm chart and install script versions for 1.3.1 release

### DIFF
--- a/biosdk-services/pom.xml
+++ b/biosdk-services/pom.xml
@@ -6,7 +6,7 @@
 
 	<artifactId>biosdk-services</artifactId>
 	<groupId>io.mosip.biosdk</groupId>
-	<version>1.3.1-rc.1</version>
+	<version>1.3.1-SNAPSHOT</version>
 	<name>biosdk-services</name>
 	<description>Sample implementation of biometrics SDK services</description>
 	<url>https://github.com/mosip/biosdk-services</url>
@@ -41,10 +41,10 @@
 		<springdoc.openapi.starter.webmvc.ui.version>2.5.0</springdoc.openapi.starter.webmvc.ui.version>
 
 		<!-- Mosip kernel -->
-		<kernel.bom.version>1.3.1-rc.1</kernel.bom.version>
-		<kernel.core.version>1.3.1-rc.1</kernel.core.version>
+		<kernel.bom.version>1.3.1-SNAPSHOT</kernel.bom.version>
+		<kernel.core.version>1.3.1-SNAPSHOT</kernel.core.version>
 		<kernel.biometrics.api.version>1.3.0</kernel.biometrics.api.version>
-		<kernel.logger.logback.version>1.3.1-rc.1</kernel.logger.logback.version>
+		<kernel.logger.logback.version>1.3.1-SNAPSHOT</kernel.logger.logback.version>
 		<sonar.coverage.exclusions>**/dto/**, **/config/**, **/constants/**, **/Status/**
 		</sonar.coverage.exclusions>
 	</properties>

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -7,7 +7,7 @@ if [ $# -ge 1 ] ; then
 fi
 
 NS=biosdk
-CHART_VERSION=1.3.1-rc.1-develop
+CHART_VERSION=1.3.1-develop
 
 echo Create $NS namespace
 kubectl create ns $NS

--- a/helm/biosdk-service/Chart.yaml
+++ b/helm/biosdk-service/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: biosdk-service
 description: A Helm chart for MOSIP Auditmanager module
 type: application
-version: 1.3.1-rc.1-develop
+version: 1.3.1-develop
 appVersion: ""
 dependencies:
   - name: common

--- a/helm/biosdk-service/values.yaml
+++ b/helm/biosdk-service/values.yaml
@@ -46,8 +46,8 @@ service:
   externalTrafficPolicy: Cluster
 image:
   registry: docker.io
-  repository: mosipid/biosdk-server
-  tag: 1.3.1-rc.1
+  repository: mosipqa/biosdk-server
+  tag: 1.3.x
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
Convert rc versions to SNAPSHOT in pom.xml, update Chart.yaml and install.sh chart_version to 1.3.1-develop, and point values.yaml image repository to mosipqa with tag 1.3.x.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the service and deployment versions to the 1.3.1 development release.
  * Updated selected platform component versions to their 1.3.1 snapshot builds.
  * Updated the deployment image to use the 1.3.x image stream.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->